### PR TITLE
Make initial metadata loading more responsive

### DIFF
--- a/src/components/integration/document-picker.tsx
+++ b/src/components/integration/document-picker.tsx
@@ -371,18 +371,25 @@ export function DocumentPicker({
   };
 
   const renderContent = () => {
-    if (loading || syncing) {
+    if (loading && documents.length === 0) {
       return (
         <div className="flex flex-col items-center justify-center py-12">
           <Icons.spinner className="h-8 w-8 animate-spin mb-4" />
-          <p className="text-sm text-gray-500">
-            {syncing ? "Syncing documents..." : "Loading documents..."}
-          </p>
+          <p className="text-sm text-gray-500">Loading documents...</p>
         </div>
       );
     }
 
-    if (error) {
+    if (syncing && documents.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center py-12">
+          <Icons.spinner className="h-8 w-8 animate-spin mb-4" />
+          <p className="text-sm text-gray-500">Syncing documents...</p>
+        </div>
+      );
+    }
+
+    if (error && documents.length === 0) {
       return (
         <div className="flex flex-col items-center justify-center py-12">
           <div className="mb-4 p-4 text-red-500 bg-red-50 rounded-md">
@@ -467,19 +474,27 @@ export function DocumentPicker({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[600px]">
         <DialogHeader>
-          <div className="flex items-center gap-3 mb-4">
-            {integration.logoUri ? (
-              <img
-                src={integration.logoUri}
-                alt={`${integration.name} logo`}
-                className="w-8 h-8 rounded-lg"
-              />
-            ) : (
-              <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center">
-                {integration.name[0]}
+          <div className="flex items-center justify-between gap-3 mb-4">
+            <div className="flex items-center gap-3">
+              {integration.logoUri ? (
+                <img
+                  src={integration.logoUri}
+                  alt={`${integration.name} logo`}
+                  className="w-8 h-8 rounded-lg"
+                />
+              ) : (
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center">
+                  {integration.name[0]}
+                </div>
+              )}
+              <DialogTitle>{integration.name}</DialogTitle>
+            </div>
+            {(loading || syncing) && documents.length > 0 && (
+              <div className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700">
+                <Icons.spinner className="h-3 w-3 animate-spin" />
+                <span>{syncing ? "Syncing" : "Loading"}</span>
               </div>
             )}
-            <DialogTitle>{integration.name}</DialogTitle>
           </div>
 
           <div className="flex justify-between items-center gap-4">

--- a/src/components/integration/document-picker.tsx
+++ b/src/components/integration/document-picker.tsx
@@ -112,6 +112,14 @@ export function DocumentPicker({
 
         const data = await response.json();
 
+        if (data.status === "in_progress") {
+          /*
+           * TODO: Ideally, we only want to fetch only new documents and append that to an array of documents
+           * We'd need to update the knowledge model to include a lastSyncedAt field so
+           * we can fetch only documents that were created after the lastSyncedAt date
+           */
+          fetchDocuments();
+        }
         if (data.status === "completed") {
           clearInterval(pollInterval);
           setSyncing(false);


### PR DESCRIPTION
## Summary by Sourcery

Improve the initial metadata loading experience by displaying documents as they become available and indicating background syncing progress.  Add visual cues to communicate loading and syncing states more clearly to the user.

Enhancements:
- Improve the responsiveness of the document picker by loading already fetched documents while syncing new ones in the background.
- Add a loading indicator during the initial document loading and syncing phases when there are no documents displayed yet.
- Display a loading or syncing indicator in the dialog header when more documents are being fetched or synced while some documents are already displayed.