### PR TITLE
Make `parentId` optional everywhere

### DIFF
--- a/src/app/api/webhooks/on-update/route.ts
+++ b/src/app/api/webhooks/on-update/route.ts
@@ -10,7 +10,7 @@ const webhookSchema = z.object({
     title: z.string().min(1).max(255),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
-    parentId: z.string().min(1).max(100),
+    parentId: z.string().optional(),
     canHaveChildren: z.boolean(),
     resourceURI: z.string().url().max(2048),
   }),


### PR DESCRIPTION
## Summary by Sourcery

This pull request makes the `parentId` field optional in the webhook schema for document creation and updates. It also fixes a bug where the subscription status and download trigger were not correctly determined when a document had no parent.

Bug Fixes:
- Fix a bug where the subscription status and download trigger were not correctly determined when a document had no parent.

Enhancements:
- Make the `parentId` field optional in the webhook schema for both document creation and updates.